### PR TITLE
fix misaligned table

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ make
 
 ## CNN-based Face Detection on ARM Linux (Raspberry Pi 3 B+)
 
-(* to be updated)
+(To be updated)
+
 | Method             |Time          | FPS         |Time          | FPS         |
 |--------------------|--------------|-------------|--------------|-------------|
 |                    |Single-thread |Single-thread|Multi-thread  |Multi-thread |


### PR DESCRIPTION
Update the Readme to fix the misaligned table in the Benchmark section for ARM Linux.

![](https://user-images.githubusercontent.com/47669588/70234172-10045f80-1786-11ea-943b-f3d99601629c.png)
