### PR TITLE
Update facedetectcnn.h

### DIFF
--- a/src/facedetectcnn.h
+++ b/src/facedetectcnn.h
@@ -390,6 +390,14 @@ public:
         stride = 0;
         scale = 0;
     }
+    ~Filters()
+    {
+	for (int i = 0; i < filters.size(); i++)
+	{
+	    delete filters[i];
+	    filters[i] = 0;
+	}
+    }
 };
 
 bool convertInt2Float(CDataBlob<int> * inputData, CDataBlob<float> * outputData);


### PR DESCRIPTION
fix a memory leakage problem.
memory used in vector<CDataBlob<signed char> *> filters is not released.