### PR TITLE
Fixed Windows compiler warnings

### DIFF
--- a/src/facedetectcnn.cpp
+++ b/src/facedetectcnn.cpp
@@ -871,8 +871,8 @@ bool detection_output(const CDataBlob<float> * priorbox,
         float cls_score = pConf[i + 1];
         int face_idx = i / 2;
         float iou_score = pIoU[face_idx];
-        float conf = sqrtf(cls_score * iou_score);
-        if(conf > confidence_threshold)
+        float confidence = sqrtf(cls_score * iou_score);
+        if(confidence > confidence_threshold)
         {
             float fBox_x1 = pPriorBox[face_idx * 4];
             float fBox_y1 = pPriorBox[face_idx * 4 + 1];
@@ -920,7 +920,7 @@ bool detection_output(const CDataBlob<float> * priorbox,
                 bb.lm[i * 2 + 1] = lmy;
             }
 
-            score_bbox_vec.push_back(std::make_pair(conf, bb));
+            score_bbox_vec.push_back(std::make_pair(confidence, bb));
         }
     }
 

--- a/src/facedetectcnn.h
+++ b/src/facedetectcnn.h
@@ -206,10 +206,10 @@ public:
 //#endif
         for (int r = 0; r < this->height; r++)
         {
-            for (int c = 0; c < this->width; c++)
+            for (int col = 0; col < this->width; col++)
             {
                 int pixel_end = this->channelStep / sizeof(T);
-                T * pI = (this->data + (size_t(r) * this->width + c) * this->channelStep /sizeof(T));
+                T * pI = (this->data + (size_t(r) * this->width + col) * this->channelStep /sizeof(T));
                 for (int ch = this->channels; ch < pixel_end; ch++)
                     pI[ch] = 0;
             }
@@ -218,7 +218,7 @@ public:
         return true;
 	}
 
-    bool setInt8FilterData(signed char * pData, int bias, int dataWidth, int dataHeight, int dataChannels)
+    bool setInt8FilterData(signed char * pData, int dataBias, int dataWidth, int dataHeight, int dataChannels)
     {
         if (pData == NULL)
         {
@@ -250,7 +250,7 @@ public:
                 }
             }
         
-        this->bias = bias;
+        this->bias = dataBias;
         return true;
     }
 


### PR DESCRIPTION
The patch fixes 3 Windows compiler warnings when compiling on level /W4:

- facedetectcnn.cpp(874): warning C4457: declaration of 'conf' hides function parameter
- facedetectcnn.h(209): warning C4457: declaration of 'c' hides function parameter
- facedetectcnn.h(221): warning C4458: declaration of 'bias' hides class member
