### PR TITLE
补上漏了的字母

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -35,7 +35,7 @@ If you want to run the examples. you must be isntalled opencv library and set Op
 mkdir build
 cd build
 cmake .. -DDEMO=ON -DOpenCV_DIR=
-cmak --build . 
+cmake --build . 
 ```
 
 - Third-party examples


### PR DESCRIPTION
[How to compile the library](https://github.com/ShiqiYu/libfacedetection/blob/master/COMPILE.md)里Example下面的最后一行命令中`cmak --build . `应该是`cmake --build . `