### PR TITLE
Specify the axis to np.squeeze

### DIFF
--- a/opencv_dnn/python/detect.py
+++ b/opencv_dnn/python/detect.py
@@ -88,7 +88,7 @@ if dets.shape[0] > 0:
           nms_threshold=args.nms_thresh,
           eta=1,
           top_k=args.keep_top_k) # returns [box_num, class_num]
-     keep_idx = np.squeeze(keep_idx) # [box_num, class_num] -> [box_num]
+     keep_idx = np.squeeze(keep_idx, axis=1) # [box_num, class_num] -> [box_num]
      dets = dets[keep_idx]
      print('Detection results: {} faces found'.format(dets.shape[0]))
      for d in dets:


### PR DESCRIPTION
When there is only one face in the input image, the original implementation gives an error

```
Traceback (most recent call last):
  File "python/detect.py", line 96, in <module>
    x1=d[0], y1=d[1], x2=d[2], y2=d[3], score=d[-1]))
IndexError: invalid index to scalar variable.
```

This commit fixes that error.