### PR TITLE
Increase CMake minimum required version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ android/gradlew
 
 **/__pycache__
 .vscode
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 # CMakeLists for libfacedetectcnn
-
+cmake_minimum_required(VERSION 3.10)
 project(libfacedetection)
-
-cmake_minimum_required(VERSION 2.8.12)
 
 option(ENABLE_NEON "whether use neon, if use arm please set it on" OFF)
 option(ENABLE_AVX512 "use avx512" OFF)


### PR DESCRIPTION
This PR solves CMake Compatibility Error:

```
CMake Error at CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```