### PR TITLE
Fix SIGSEGV in Highway kernels: use unaligned Load/Store on std::vector-backed blobs

### DIFF
--- a/highway/src/hw_kernels_hw.cpp
+++ b/highway/src/hw_kernels_hw.cpp
@@ -16,10 +16,10 @@ void MulAddLoop(D d, const float* a, const float* b, float* acc, int n) {
     const int lanes = static_cast<int>(hn::Lanes(d));
     int i = 0;
     for (; i + lanes <= n; i += lanes) {
-        const auto va = hn::Load(d, a + i);
-        const auto vb = hn::Load(d, b + i);
-        const auto vacc = hn::Load(d, acc + i);
-        hn::Store(hn::MulAdd(va, vb, vacc), d, acc + i);
+        const auto va = hn::LoadU(d, a + i);
+        const auto vb = hn::LoadU(d, b + i);
+        const auto vacc = hn::LoadU(d, acc + i);
+        hn::StoreU(hn::MulAdd(va, vb, vacc), d, acc + i);
     }
     for (; i < n; ++i) {
         acc[i] += a[i] * b[i];
@@ -43,7 +43,7 @@ float DotProductHw(const float* a, const float* b, int n) {
     auto sum = hn::Zero(d);
     int i = 0;
     for (; i + lanes <= n; i += lanes) {
-        sum = hn::MulAdd(hn::Load(d, a + i), hn::Load(d, b + i), sum);
+        sum = hn::MulAdd(hn::LoadU(d, a + i), hn::LoadU(d, b + i), sum);
     }
     float result = hn::ReduceSum(d, sum);
     for (; i < n; ++i) {
@@ -62,7 +62,7 @@ void AddHw(const float* a, const float* b, float* out, int n) {
     const int lanes = static_cast<int>(hn::Lanes(d));
     int i = 0;
     for (; i + lanes <= n; i += lanes) {
-        hn::Store(hn::Add(hn::Load(d, a + i), hn::Load(d, b + i)), d, out + i);
+        hn::StoreU(hn::Add(hn::LoadU(d, a + i), hn::LoadU(d, b + i)), d, out + i);
     }
     for (; i < n; ++i) {
         out[i] = a[i] + b[i];
@@ -74,7 +74,7 @@ void AddInplaceHw(const float* a, float* out, int n) {
     const int lanes = static_cast<int>(hn::Lanes(d));
     int i = 0;
     for (; i + lanes <= n; i += lanes) {
-        hn::Store(hn::Add(hn::Load(d, a + i), hn::Load(d, out + i)), d, out + i);
+        hn::StoreU(hn::Add(hn::LoadU(d, a + i), hn::LoadU(d, out + i)), d, out + i);
     }
     for (; i < n; ++i) {
         out[i] += a[i];
@@ -87,7 +87,7 @@ void ReluHw(float* data, int n) {
     const int lanes = static_cast<int>(hn::Lanes(d));
     int i = 0;
     for (; i + lanes <= n; i += lanes) {
-        hn::Store(hn::Max(hn::Load(d, data + i), zero), d, data + i);
+        hn::StoreU(hn::Max(hn::LoadU(d, data + i), zero), d, data + i);
     }
     for (; i < n; ++i) {
         data[i] = std::max(data[i], 0.0f);


### PR DESCRIPTION
## Summary

  The `highway/` module crashes with SIGSEGV on any x86 target ≥ AVX2 (e.g.
  building with `-march=skylake`, `-march=haswell`, `-march=cascadelake`). Five
  elementwise kernels in `src/hw_kernels_hw.cpp` use Highway's **aligned**
  `Load`/`Store` on blob data that is only `std::vector<float>`-aligned, which is
  narrower than the SIMD vector width.

  ## Symptom

  fdt::hw::AddHw                          hw_kernels_hw.cpp:65
  ... (any pipeline that calls AddHw / DotProductHw / ReluHw / MulAddHw / AddInplaceHw)

  SIGSEGV inside `hn::Store(hn::Add(hn::Load(...), hn::Load(...)), ...)`.

  ## Root cause

  - Blob storage is `HwBlob::data_`, a `std::vector<float>`. Its base pointer is
    only aligned to the default allocator alignment (16 bytes on x86-64 glibc),
    **not** the SIMD vector width.
  - Highway's `Load`/`Store` are the *aligned* variants and require the pointer to
    be aligned to the vector size — 32 bytes for AVX2, 64 bytes for AVX-512.
  - On an SSE target (128-bit, 16-byte alignment) the 16-byte base happens to
    satisfy the requirement, so it works. On AVX2+ the aligned move (`vmovaps`)
    hits a 16-byte-but-not-32-byte address → `#GP` → SIGSEGV.
  - Channel padding (`PaddedChannels`) makes per-pixel `Ptr()` *offsets* a multiple
    of the vector size, but the *base* `data_.data()` is still only 16-byte
    aligned, so it does not help.

  This is an inconsistency within the file itself: the other ~150 load/store sites
  already use the unaligned `LoadU`/`StoreU`. Only these 5 functions use the
  aligned variant: `MulAddLoop`, `DotProductHw`, `AddHw`, `AddInplaceHw`, `ReluHw`.